### PR TITLE
upgrade ansible lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         uses: ansible/ansible-lint-action@master
         with:
           targets: "."
+          override-deps: ansible-lint==5.3.2
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,4 +15,5 @@ galaxy_info:
     - virtualenv
 dependencies:
   - baztian.python
+  - baztian.asdf
   - baztian.java

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,4 @@
 - src: baztian.python
 - src: baztian.pip_venv
+- src: baztian.asdf
 - src: baztian.java

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 - src: baztian.pip_venv
 - src: baztian.python
 - src: baztian.java
+- src: baztian.asdf


### PR DESCRIPTION
- Fix missing java dependency
- Trigger GH Action
- Upgrade ansible lint in order to work around ansible-lint-action issue #59
